### PR TITLE
Added customizable keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 libs
+build.properties

--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@ A Titanium module for registering a device with Google Cloud Messaging and handl
 [![gitTio](http://gitt.io/badge.png)](http://gitt.io/component/nl.vanvianen.android.gcm)
 
 Read the [documentation](https://github.com/morinel/gcmpush/blob/master/documentation/index.md).
+
+To build, create a `build.properties` file with the following content:
+
+```
+titanium.platform=/Users/###USER###/Library/Application Support/Titanium/mobilesdk/osx/4.1.0.GA/android
+android.platform=/Users/###USER###/Library/Android/sdk/platforms/android-23
+google.apis=/Users/###USER###/Library/Android/sdk/add-ons/addon-google_apis-google-23
+android.ndk=/Users/###USER###/Library/Android/ndk
+```
+
+Make sure your paths are correct for your system setup. Then run:
+
+```
+$ ant clean
+$ ant
+```
+
+A zip file will be created in the `dist` folder.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -72,6 +72,12 @@ See the [example](https://github.com/morinel/gcmpush/blob/master/example/app.js)
 1. **group**: name of group to group similar notifications together, default null.
 1. **localOnly** (true / false): whether this notification should be bridged to other devices (false) or is only relevant to this device (true), default true.
 1. **priority**: (integer) specifies the priority of the notification, should be between [PRIORITY_MIN](http://developer.android.com/reference/android/support/v4/app/NotificationCompat.html#PRIORITY_MIN) and [PRIORITY_MAX](http://developer.android.com/reference/android/support/v4/app/NotificationCompat.html#PRIORITY_MAX), default 0.
+1. **titleKey** (string): specify a custom key name for the notification title sent by the server
+1. **messageKey** (string): specify a custom key name for the notification message sent by the server
+1. **tickerKey** (string): specify a custom key name for the notification ticker text sent by the server
+1. **title** (string): specify a static title for the notification (server data will be ignored)
+1. **message** (string): specify a static message for the notification (server data will be ignored)
+1. **ticker** (string): specify a static ticker for the notification (server data will be ignored)
 
 The settings sound, vibrate, insistent, group, localOnly and priority can also be set as data in the push message being received (see the server-side example above).
 

--- a/example/app.js
+++ b/example/app.js
@@ -12,14 +12,22 @@ gcm.registerPush({
 	/* It's the same as your project id */
 	senderId: 'XXXXXXXX',
 	notificationSettings: {
-		sound: 'mysound.mp3', /* Place soudn file in platform/android/res/raw/mysound.mp3 */
+		sound: 'mysound.mp3', /* Place sound file in platform/android/res/raw/mysound.mp3 */
 		smallIcon: 'notification_icon.png',  /* Place icon in platform/android/res/drawable/notification_icon.png */
 		largeIcon: 'appicon.png',  /* Same */
 		vibrate: true,  /* Whether the phone should vibrate */
 		insistent: true,  /* Whether the notification should be insistent */
 		group: 'MyNotificationGroup',  /* Name of group to group similar notifications together */
         localOnly: false,  /* Whether this notification should be bridged to other devices */
-        priority: +2  /* Notification priority, from -2 to +2 */
+        priority: +2,  /* Notification priority, from -2 to +2 */
+        /* You can customize the key name of the title, message, and ticker values if you don't have control over how the notification is sent */
+        titleKey: 'title',
+        messageKey: 'message',
+        tickerKey: 'ticker',
+        /* You can also set a static value for title, message, or ticker. If you set a value here, the key will be ignored. */
+        title: '',
+        message: '',
+        ticker: ''
 	},
 	success: function (event) {
 		Ti.API.info("Push registration success: " + JSON.stringify(event));

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.2
+version: 1.3
 apiversion: 3
 description: Google Cloud Push for Titanium
 author: Jeroen van Vianen <jeroen@vanvianen.nl>
@@ -14,5 +14,5 @@ name: Gcm
 moduleid: nl.vanvianen.android.gcm
 guid: A2371685-B58E-42E4-8403-DF23A877FF0C
 platform: android
-minsdk: 3.5.1
+minsdk: 4.1.0
 architectures: armeabi;armeabi-v7a;x86

--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -153,11 +153,9 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
 
             if (notificationSettings.get("sound") instanceof String) {
-                if (notificationSettings.get("sound") != null) {
-                    sound = (String) notificationSettings.get("sound");
-                } else {
-                    Log.e(LCAT, "Invalid setting sound, should be string");
-                }
+                sound = (String) notificationSettings.get("sound");
+            } else {
+                Log.e(LCAT, "Invalid setting sound, should be string");
             }
 
             if (notificationSettings.get("vibrate") != null) {
@@ -203,51 +201,39 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
 
             if (notificationSettings.get("titleKey") instanceof String) {
-                if (notificationSettings.get("titleKey") != null) {
-                    titleKey = (String) notificationSettings.get("titleKey");
-                } else {
-                    Log.e(LCAT, "Invalid setting titleKey, should be string");
-                }
+                titleKey = (String) notificationSettings.get("titleKey");
+            } else {
+                Log.e(LCAT, "Invalid setting titleKey, should be string");
             }
 
             if (notificationSettings.get("messageKey") instanceof String) {
-                if (notificationSettings.get("messageKey") != null) {
-                    messageKey = (String) notificationSettings.get("messageKey");
-                } else {
-                    Log.e(LCAT, "Invalid setting messageKey, should be string");
-                }
+                messageKey = (String) notificationSettings.get("messageKey");
+            } else {
+                Log.e(LCAT, "Invalid setting messageKey, should be string");
             }
 
             if (notificationSettings.get("tickerKey") instanceof String) {
-                if (notificationSettings.get("tickerKey") != null) {
-                    tickerKey = (String) notificationSettings.get("tickerKey");
-                } else {
-                    Log.e(LCAT, "Invalid setting tickerKey, should be string");
-                }
+                tickerKey = (String) notificationSettings.get("tickerKey");
+            } else {
+                Log.e(LCAT, "Invalid setting tickerKey, should be string");
             }
 
             if (notificationSettings.get("title") instanceof String) {
-                if (notificationSettings.get("title") != null) {
-                    title = (String) notificationSettings.get("title");
-                } else {
-                    Log.e(LCAT, "Invalid setting title, should be string");
-                }
+                title = (String) notificationSettings.get("title");
+            } else {
+                Log.e(LCAT, "Invalid setting title, should be string");
             }
 
             if (notificationSettings.get("message") instanceof String) {
-                if (notificationSettings.get("message") != null) {
-                    message = (String) notificationSettings.get("message");
-                } else {
-                    Log.e(LCAT, "Invalid setting message, should be string");
-                }
+                message = (String) notificationSettings.get("message");
+            } else {
+                Log.e(LCAT, "Invalid setting message, should be string");
             }
 
             if (notificationSettings.get("ticker") instanceof String) {
-                if (notificationSettings.get("ticker") != null) {
-                    ticker = (String) notificationSettings.get("ticker");
-                } else {
-                    Log.e(LCAT, "Invalid setting ticker, should be string");
-                }
+                ticker = (String) notificationSettings.get("ticker");
+            } else {
+                Log.e(LCAT, "Invalid setting ticker, should be string");
             }
 
         } else {

--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -152,10 +152,12 @@ public class GCMIntentService extends GCMBaseIntentService {
                 Log.e(LCAT, "Invalid setting largeIcon, should be String");
             }
 
-            if (notificationSettings.get("sound") instanceof String) {
-                sound = (String) notificationSettings.get("sound");
-            } else {
-                Log.e(LCAT, "Invalid setting sound, should be string");
+            if (notificationSettings.get("sound") != null) {
+                if (notificationSettings.get("sound") instanceof String) {
+                    sound = (String) notificationSettings.get("sound");
+                } else {
+                    Log.e(LCAT, "Invalid setting sound, should be string");
+                }
             }
 
             if (notificationSettings.get("vibrate") != null) {
@@ -200,40 +202,52 @@ public class GCMIntentService extends GCMBaseIntentService {
                 }
             }
 
-            if (notificationSettings.get("titleKey") instanceof String) {
-                titleKey = (String) notificationSettings.get("titleKey");
-            } else {
-                Log.e(LCAT, "Invalid setting titleKey, should be string");
+            if (notificationSettings.get("titleKey") != null) {
+                if (notificationSettings.get("titleKey") instanceof String) {
+                    titleKey = (String) notificationSettings.get("titleKey");
+                } else {
+                    Log.e(LCAT, "Invalid setting titleKey, should be string");
+                }
             }
 
-            if (notificationSettings.get("messageKey") instanceof String) {
-                messageKey = (String) notificationSettings.get("messageKey");
-            } else {
-                Log.e(LCAT, "Invalid setting messageKey, should be string");
+            if (notificationSettings.get("messageKey") != null) {
+                if (notificationSettings.get("messageKey") instanceof String) {
+                    messageKey = (String) notificationSettings.get("messageKey");
+                } else {
+                    Log.e(LCAT, "Invalid setting messageKey, should be string");
+                }
             }
 
-            if (notificationSettings.get("tickerKey") instanceof String) {
-                tickerKey = (String) notificationSettings.get("tickerKey");
-            } else {
-                Log.e(LCAT, "Invalid setting tickerKey, should be string");
+            if (notificationSettings.get("tickerKey") != null) {
+                if (notificationSettings.get("tickerKey") instanceof String) {
+                    tickerKey = (String) notificationSettings.get("tickerKey");
+                } else {
+                    Log.e(LCAT, "Invalid setting tickerKey, should be string");
+                }
             }
 
-            if (notificationSettings.get("title") instanceof String) {
-                title = (String) notificationSettings.get("title");
-            } else {
-                Log.e(LCAT, "Invalid setting title, should be string");
+            if (notificationSettings.get("title") != null) {
+                if (notificationSettings.get("title") instanceof String) {
+                    title = (String) notificationSettings.get("title");
+                } else {
+                    Log.e(LCAT, "Invalid setting title, should be string");
+                }
             }
 
-            if (notificationSettings.get("message") instanceof String) {
-                message = (String) notificationSettings.get("message");
-            } else {
-                Log.e(LCAT, "Invalid setting message, should be string");
+            if (notificationSettings.get("message") != null) {
+                if (notificationSettings.get("message") instanceof String) {
+                    message = (String) notificationSettings.get("message");
+                } else {
+                    Log.e(LCAT, "Invalid setting message, should be string");
+                }
             }
 
-            if (notificationSettings.get("ticker") instanceof String) {
-                ticker = (String) notificationSettings.get("ticker");
-            } else {
-                Log.e(LCAT, "Invalid setting ticker, should be string");
+            if (notificationSettings.get("ticker") != null) {
+                if (notificationSettings.get("ticker") instanceof String) {
+                    ticker = (String) notificationSettings.get("ticker");
+                } else {
+                    Log.e(LCAT, "Invalid setting ticker, should be string");
+                }
             }
 
         } else {

--- a/timodule.xml
+++ b/timodule.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
-        <manifest package="nl.vanvianen.android.gcm" android:versionCode="3" android:versionName="1.2" android:installLocation="internalOnly">
+        <manifest package="nl.vanvianen.android.gcm" android:versionCode="3" android:versionName="1.3" android:installLocation="internalOnly">
             <supports-screens android:anyDensity="true"/>
             <uses-sdk android:minSdkVersion="10"/>
             


### PR DESCRIPTION
Added settings to notificationSettings for message keys and static
values. Also added JSON parsing of data that can be used via the custom
keys settings.

I’m using Parse.com for push notifications, and the data sent to the device does not conform to the `title, message, ticker` format that this module expects. The data is passed via JSON, so I added JSON parsing so that I could do something like getting the notification message from the `alert` JSON value.