### PR TITLE
Show notifications only when the app is in the background

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,4 @@
+titanium.platform=/Users/timpoulsen/Library/Application Support/Titanium/mobilesdk/osx/4.0.0.GA/android
+android.platform=/Users/timpoulsen/Library/Android/sdk/platforms/android-23
+google.apis=/Users/timpoulsen/Library/Android/sdk/add-ons/addon-google_apis-google-23
+android.ndk=/Users/timpoulsen/android-ndk-r10e

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-titanium.platform=/Users/timpoulsen/Library/Application Support/Titanium/mobilesdk/osx/4.0.0.GA/android
-android.platform=/Users/timpoulsen/Library/Android/sdk/platforms/android-23
-google.apis=/Users/timpoulsen/Library/Android/sdk/add-ons/addon-google_apis-google-23
-android.ndk=/Users/timpoulsen/android-ndk-r10e
+titanium.platform=/Users/timpoulsen/Library/Application Support/Titanium/mobilesdk/osx/5.1.1.GA/android
+android.platform=/Users/timpoulsen/android-sdk/platforms/android-23
+google.apis=/Users/timpoulsen/android-sdk/add-ons/addon-google_apis-google-23
+android.ndk=/Users/timpoulsen/android-ndk-r8

--- a/manifest
+++ b/manifest
@@ -8,11 +8,13 @@ author: Jeroen van Vianen <jeroen@vanvianen.nl>
 license: Apache License, Version 2.0
 copyright: Copyright (c) 2015 by Jeroen van Vianen
 
+apiversion: 2
+architectures: armeabi armeabi-v7a x86
+
+
 # these should not be edited
 name: Gcm
 moduleid: nl.vanvianen.android.gcm
-id: nl.vanvianen.android.gcm
 guid: A2371685-B58E-42E4-8403-DF23A877FF0C
 platform: android
-minsdk: 4.0.0.GA
-architectures: armeabi;armeabi-v7a;x86
+minsdk: 5.1.1.GA

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.3
+version: 1.3.1
 description: Google Cloud Push for Titanium
 author: Jeroen van Vianen <jeroen@vanvianen.nl>
 license: Apache License, Version 2.0
@@ -11,6 +11,7 @@ copyright: Copyright (c) 2015 by Jeroen van Vianen
 # these should not be edited
 name: Gcm
 moduleid: nl.vanvianen.android.gcm
+id: nl.vanvianen.android.gcm
 guid: A2371685-B58E-42E4-8403-DF23A877FF0C
 platform: android
 minsdk: 4.0.0.GA

--- a/src/nl/vanvianen/android/gcm/AppStateListener.java
+++ b/src/nl/vanvianen/android/gcm/AppStateListener.java
@@ -1,0 +1,33 @@
+//
+//   Copyright 2013 jordi domenech <http://iamyellow.net, jordi@iamyellow.net>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+/**
+ * Code borrowed from gcm.js: https://github.com/iamyellow/gcm.js/blob/master/src/net/iamyellow/gcmjs/AppStateListener.java
+ */
+
+package nl.vanvianen.android.gcm;
+
+import org.appcelerator.titanium.TiApplication.ActivityTransitionListener;
+
+public class AppStateListener implements ActivityTransitionListener  {
+	public static boolean oneActivityIsResumed = false;
+	public static boolean appWasNotRunning = false;
+
+	@Override
+	public void onActivityTransition (boolean state) {
+		oneActivityIsResumed = !state;
+	}
+}

--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -111,6 +111,7 @@ public class GCMIntentService extends GCMBaseIntentService {
         String group = null;
         boolean localOnly = true;
         int priority = 0;
+        boolean backgroundOnly = false;
 
         Map<String, Object> notificationSettings = new Gson().fromJson(TiApplication.getInstance().getAppProperties().getString(GCMModule.NOTIFICATION_SETTINGS, null), Map.class);
         if (notificationSettings != null) {
@@ -176,6 +177,14 @@ public class GCMIntentService extends GCMBaseIntentService {
                 }
             }
 
+            if (notificationSettings.get("backgroundOnly") != null) {
+                if (notificationSettings.get("backgroundOnly") instanceof Boolean) {
+                    backgroundOnly = (Boolean) notificationSettings.get("backgroundOnly");
+                } else {
+                    Log.e(LCAT, "Invalid setting backgroundOnly, should be boolean");
+                }
+            }
+
         } else {
             Log.d(LCAT, "No notification settings found");
         }
@@ -203,6 +212,11 @@ public class GCMIntentService extends GCMBaseIntentService {
         Log.i(LCAT, "Title: " + title);
         Log.i(LCAT, "Message: " + message);
         Log.i(LCAT, "Ticker: " + ticker);
+
+        if (backgroundOnly && GCMModule.getInstance().isInForeground()) {
+            Log.d(LCAT, "Notification received in foreground, no need for notification.");
+            return;
+        }
 
         if (message == null) {
             Log.d(LCAT, "Message received but no 'message' specified in push notification payload, so will make this silent");

--- a/timodule.xml
+++ b/timodule.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
-        <manifest package="nl.vanvianen.android.gcm" android:versionCode="3" android:versionName="1.2" android:installLocation="internalOnly">
+        <manifest package="nl.vanvianen.android.gcm" android:versionCode="4" android:versionName="1.3.1" android:installLocation="internalOnly">
             <supports-screens android:anyDensity="true"/>
             <uses-sdk android:minSdkVersion="21"/>
             


### PR DESCRIPTION
Implements the changes at https://github.com/cr0ybot/gcmpush/commit/c392b2cc740f0ccf10dc7e6823bdf66ac041d571 

Adds a backgroundOnly configuration setting. If `true` the module will create a notification only when the app is in the background.

I'm not sure why @cr0ybot never submitted this as a PR. @cr0ybot, if you object to me submitting the PR or want to be the contributor, please say so and I'll close this PR. I'm not trying to steal credit for your work. But I needed this feature and figured it should be rolled back into the main repo. 