### PR TITLE
Receive notification data in foreground using backgroundOnly

### DIFF
--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -349,21 +349,20 @@ public class GCMIntentService extends GCMBaseIntentService {
         Log.i(LCAT, "Message: " + message);
         Log.i(LCAT, "Ticker: " + ticker);
 
-		/* Check for app state */
+        /* Check for app state */
         if (GCMModule.getInstance() != null) {
-        	/* Send data to app */
+            /* Send data to app */
             if (isTopic) {
                 GCMModule.getInstance().sendTopicMessage(data);
             } else {
                 GCMModule.getInstance().sendMessage(data);
             }
-
-			/* Do not create notification if backgroundOnly and app is in foreground */
+            /* Do not create notification if backgroundOnly and app is in foreground */
             if (backgroundOnly && GCMModule.getInstance().isInForeground()) {
                 Log.d(LCAT, "Notification received in foreground, no need for notification.");
                 return;
             }
-		}
+        }
 
         if (message == null) {
             Log.d(LCAT, "Message received but no 'message' specified in push notification payload, so will make this silent");

--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -349,10 +349,21 @@ public class GCMIntentService extends GCMBaseIntentService {
         Log.i(LCAT, "Message: " + message);
         Log.i(LCAT, "Ticker: " + ticker);
 
-        if (backgroundOnly && GCMModule.getInstance().isInForeground()) {
-            Log.d(LCAT, "Notification received in foreground, no need for notification.");
-            return;
-        }
+		/* Check for app state */
+        if (GCMModule.getInstance() != null) {
+        	/* Send data to app */
+            if (isTopic) {
+                GCMModule.getInstance().sendTopicMessage(data);
+            } else {
+                GCMModule.getInstance().sendMessage(data);
+            }
+
+			/* Do not create notification if backgroundOnly and app is in foreground */
+            if (backgroundOnly && GCMModule.getInstance().isInForeground()) {
+                Log.d(LCAT, "Notification received in foreground, no need for notification.");
+                return;
+            }
+		}
 
         if (message == null) {
             Log.d(LCAT, "Message received but no 'message' specified in push notification payload, so will make this silent");
@@ -474,14 +485,6 @@ public class GCMIntentService extends GCMBaseIntentService {
             notification.flags |= Notification.FLAG_AUTO_CANCEL;
 
             ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE)).notify(notificationId, notification);
-        }
-
-        if (GCMModule.getInstance() != null) {
-            if (isTopic) {
-                GCMModule.getInstance().sendTopicMessage(data);
-            } else {
-                GCMModule.getInstance().sendMessage(data);
-            }
         }
     }
 


### PR DESCRIPTION
Code for sending the notification data to the app is never sent at all if `backgroundOnly` is true. The `backgroundOnly` setting should only apply to system notifications; the app callback should be fired while the app is in the foreground.

This fixes issue #41.