### PR TITLE
Update manifest to build with Titanium 6+

### DIFF
--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.6
+version: 2.0
 apiversion: 3
 description: Google Cloud Push for Titanium
 author: Jeroen van Vianen <jeroen@vanvianen.nl>
@@ -14,5 +14,5 @@ name: Gcm
 moduleid: nl.vanvianen.android.gcm
 guid: A2371685-B58E-42E4-8403-DF23A877FF0C
 platform: android
-minsdk: 5.1.2.GA
-architectures: armeabi;armeabi-v7a;x86;x86_64
+minsdk: 6.0.0
+architectures: armeabi-v7a x86 x86_64


### PR DESCRIPTION
This updates the manifest to build against Titanium 6 and V8 5.1.281.59. Once merged you need to re-run ant to build the new zip. (Needs to be built against a 6.0.0+ master SDK build right now).