### PR TITLE
Update for Titanium SDK 6.0.0, bugfix, and README info about NDK r11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ A Titanium module for registering a device with Google Cloud Messaging and handl
 
 Read the [documentation](https://github.com/morinel/gcmpush/blob/master/documentation/index.md).
 
-To build, create a `build.properties` file with the following content:
+## Building
+
+Version 2.0+ of this module is only compatible with Titanium SDK 6+. Currently, Android NDK r11 is required to build the module without errors.
+
+[Windows 32-bit](https://dl.google.com/android/repository/android-ndk-r11-windows-x86.zip) | [Windows 64-bit](https://dl.google.com/android/repository/android-ndk-r11-windows-x86_64.zip) | [Mac OS X 64-bit](https://dl.google.com/android/repository/android-ndk-r11-darwin-x86_64.zip) | [Linux 64-bit](https://dl.google.com/android/repository/android-ndk-r11-linux-x86_64.zip)
+
+Create a `build.properties` file with the following content:
 
 ```
-titanium.platform=/Users/###USER###/Library/Application Support/Titanium/mobilesdk/osx/5.1.2.GA/android
+titanium.platform=/Users/###USER###/Library/Application Support/Titanium/mobilesdk/osx/6.0.0.GA/android
 android.platform=/Users/###USER###/Library/Android/sdk/platforms/android-23
 google.apis=/Users/###USER###/Library/Android/sdk/add-ons/addon-google_apis-google-23
-android.ndk=/Users/###USER###/Library/Android/ndk
+android.ndk=/Users/###USER###/Library/Android/android-ndk-r11
 ```
 
 Make sure your paths are correct for your system setup. Then run:

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.7
+version: 2.0
 apiversion: 3
 description: Google Cloud Push for Titanium
 author: Jeroen van Vianen <jeroen@vanvianen.nl>
@@ -14,5 +14,5 @@ name: Gcm
 moduleid: nl.vanvianen.android.gcm
 guid: A2371685-B58E-42E4-8403-DF23A877FF0C
 platform: android
-minsdk: 5.1.2.GA
-architectures: armeabi;armeabi-v7a;x86;x86_64
+minsdk: 6.0.0.GA
+architectures: armeabi-v7a x86 x86_64

--- a/src/nl/vanvianen/android/gcm/GCMIntentService.java
+++ b/src/nl/vanvianen/android/gcm/GCMIntentService.java
@@ -98,28 +98,31 @@ public class GCMIntentService extends GCMBaseIntentService {
             Object value = intent.getExtras().get(key);
             Log.d(LCAT, "Message key: \"" + key + "\" value: \"" + value + "\"");
 
-            if (key.equals("from") && value instanceof String && ((String) value).startsWith("/topics/")) {
-                isTopic = true;
-            }
+            if (value != null) {
 
-            String eventKey = key.startsWith("data.") ? key.substring(5) : key;
-            data.put(eventKey, intent.getExtras().get(key));
+                if (key.equals("from") && value instanceof String && ((String) value).startsWith("/topics/")) {
+                    isTopic = true;
+                }
 
-            if (value instanceof String && ((String) value).startsWith("{")) {
-                Log.d(LCAT, "Parsing JSON string...");
-                try {
-                    JSONObject json = new JSONObject((String) value);
+                String eventKey = key.startsWith("data.") ? key.substring(5) : key;
+                data.put(eventKey, intent.getExtras().get(key));
 
-                    Iterator<String> keys = json.keys();
-                    while (keys.hasNext()) {
-                        String jKey = keys.next();
-                        String jValue = json.getString(jKey);
-                        Log.d(LCAT, "JSON key: \"" + jKey + "\" value: \"" + jValue + "\"");
+                if (value instanceof String && ((String) value).startsWith("{")) {
+                    Log.d(LCAT, "Parsing JSON string...");
+                    try {
+                        JSONObject json = new JSONObject((String) value);
 
-                        data.put(jKey, jValue);
+                        Iterator<String> keys = json.keys();
+                        while (keys.hasNext()) {
+                            String jKey = keys.next();
+                            String jValue = json.getString(jKey);
+                            Log.d(LCAT, "JSON key: \"" + jKey + "\" value: \"" + jValue + "\"");
+
+                            data.put(jKey, jValue);
+                        }
+                    } catch(JSONException ex) {
+                        Log.d(LCAT, "JSON error: " + ex.getMessage());
                     }
-                } catch(JSONException ex) {
-                    Log.d(LCAT, "JSON error: " + ex.getMessage());
                 }
             }
         }

--- a/timodule.xml
+++ b/timodule.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
-        <manifest package="nl.vanvianen.android.gcm" android:versionCode="4" android:versionName="1.6" android:installLocation="internalOnly">
+        <manifest package="nl.vanvianen.android.gcm" android:versionCode="4" android:versionName="2.0" android:installLocation="internalOnly">
             <supports-screens android:anyDensity="true"/>
             <uses-sdk android:minSdkVersion="21"/>
             


### PR DESCRIPTION
I know there's already another pending pull request for an update to SDK 6, but using that build was crashing my app every time a notification was received. So I fixed that with a check for null when a message is received... but then I was unable to build the module myself. I found out that SDK 6 currently only supports Android NDK r11. That worked, so I updated the README.